### PR TITLE
Move playback updates to OPM timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-out/*.x
+out
+obj
 src/*.o
 *.map
 *.x

--- a/src/irq.h
+++ b/src/irq.h
@@ -1,6 +1,7 @@
 #ifndef IRQ_H
 #define IRQ_H
 
-void g_irq_vbl(void);  // <-- src/irq.s
+void g_irq_vbl(void);  // <-- src/xt_irq.c
+void g_irq_opm(void);  // <-- src/main.c
 
 #endif  // IRQ_H

--- a/src/irq.s
+++ b/src/irq.s
@@ -1,8 +1,0 @@
-	.extern	g_xt_vbl_pending
-
-	align 2
-.global	g_irq_vbl
-
-g_irq_vbl:
-	clr.w	g_xt_vbl_pending
-	rte

--- a/src/x68000/x68k_irq.h
+++ b/src/x68000/x68k_irq.h
@@ -1,0 +1,22 @@
+#ifndef _X68K_IRQ_H
+#define _X68K_IRQ_H
+
+#include <stdint.h>
+
+#define ISR  __attribute__((__interrupt_handler__))
+
+#define IPL_ALLOW_ALL  0
+#define IPL_ALLOW_NONE 7
+
+// optimizer should be able to catch cases where return value is unused
+static inline uint8_t set_ipl(uint8_t ipl) {
+	uint16_t sr;
+	__asm volatile ("move.w %%sr, %0" : "=r" (sr));
+	uint8_t old_ipl = (sr >> 8) & 7;
+	sr &= ~(7 << 8);
+	sr |= (uint16_t)ipl << 8;
+	__asm volatile ("move.w %0, %%sr" : : "r" (sr));
+	return old_ipl;
+}
+
+#endif

--- a/src/xt_irq.c
+++ b/src/xt_irq.c
@@ -1,3 +1,4 @@
+#include "x68000/x68k_irq.h"
 #include "xt_irq.h"
 #include "irq.h"
 
@@ -6,22 +7,33 @@ volatile uint16_t g_xt_vbl_pending;
 
 static void *s_old_vbl_isr;
 
+static uint8_t s_old_ierb;
+static uint8_t s_old_imrb;
+
+static uint8_t s_old_ipl;
+
 void xt_irq_init(void)
 {
-	
+	// temporarily disable IRQs while we poke IRQ configuration
+	s_old_ipl = set_ipl(IPL_ALLOW_NONE);
+
 	s_old_vbl_isr = _iocs_b_intvcs(0x46, g_irq_vbl);
 
 	// Enable the VBL int.
 	volatile uint8_t *ierb = (volatile uint8_t *)0xE88009;
 	volatile uint8_t *imrb = (volatile uint8_t *)0xE88015;
+	s_old_ierb = *ierb;
+	s_old_imrb = *imrb;
 	*ierb = 0x40;
 	*imrb = 0x40;
 
 	// Set OPM int.
-//	_iocs_opmintst(g_irq_opm);
+	//	_iocs_opmintst(g_irq_opm);
 
 	// TODO: How are you supposed to use this?
 	// _iocs_vdispst(g_irq_vbl, 0, 0);
+
+	set_ipl(IPL_ALLOW_ALL);
 }
 
 void xt_irq_wait_vbl(void)
@@ -38,10 +50,12 @@ void xt_irq_wait_vbl(void)
 
 void xt_irq_shutdown(void)
 {
+	set_ipl(IPL_ALLOW_NONE);
 	volatile uint8_t *ierb = (volatile uint8_t *)0xE88009;
 	volatile uint8_t *imrb = (volatile uint8_t *)0xE88015;
-	*ierb &= ~0x40;
-	*imrb &= ~0x40;
+	*ierb = s_old_ierb;
+	*imrb = s_old_imrb;
 
 	_iocs_b_intvcs(0x46, s_old_vbl_isr);
+	set_ipl(s_old_ipl);
 }

--- a/src/xt_irq.h
+++ b/src/xt_irq.h
@@ -7,7 +7,7 @@
 extern volatile uint16_t g_xt_vbl_pending;
 
 // Register the XT VBlank IRQ.
-void xt_irq_init(void);
+int xt_irq_init(void);
 
 // Wait for vblank.
 void xt_irq_wait_vbl(void);


### PR DESCRIPTION
Instead of tying music playback to VSYNC, we tick the player at a rate determined by OPM timer A.